### PR TITLE
Onboarding: Ask and show gender to users

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,8 +7,9 @@ import WaitingForChat from "@/components/sections/WaitingForChat";
 import { useChatSocket } from "@/hooks/useChatSocket";
 
 export default function Home() {
- 
-  const { user, partner, messages, isConnected, isWaiting, setUserName, findPartner, sendMessage } = useChatSocket();
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { user, gender, partner, partnerGender, messages, isConnected, isWaiting, setUserDetails, findPartner, sendMessage } = useChatSocket();
 
   let content;
 
@@ -16,13 +17,13 @@ export default function Home() {
     content = <NotConnected/>;
   } else {  // if connected to server
     if (!user) {
-      content = <Greeting onSubmit={setUserName} />;
+      content = <Greeting onSubmit={setUserDetails} />;
     } else { // if connected to server and username is set
       if (!isWaiting) {
         if (!partner) { // if user hasn't allowed to find matches
           content = <StartChatting name={user} onConnect={findPartner} />;
         } else { // if matches found
-          content = <Chat partner={partner} onMessage={sendMessage} messages={messages}/>;
+          content = <Chat partner={partner} partnerGender={partnerGender} onMessage={sendMessage} messages={messages}/>;
         }
       } else { // if user is waiting for a partner
         content = <WaitingForChat />;

--- a/src/components/sections/Chat.tsx
+++ b/src/components/sections/Chat.tsx
@@ -6,11 +6,12 @@ import { ChangeEvent, FormEvent, useRef, useState } from "react"
 
 type ChatProps = {
     partner: string,
+    partnerGender: string | null,
     messages: Message[],
     onMessage: (message: string|null, image: string|null) => void,
 }
 
-export default function Chat({ partner, onMessage, messages }: ChatProps) {
+export default function Chat({ partner, partnerGender, onMessage, messages }: ChatProps) {
 
     const message = useRef<HTMLInputElement>(null);
     const fileinput = useRef<HTMLInputElement>(null);
@@ -65,7 +66,7 @@ export default function Chat({ partner, onMessage, messages }: ChatProps) {
             <header className="fixed top-0 left-0 w-full bg-background">
                 <div className="w-[1080px] max-w-full p-4 m-auto">
                     <h4>You&apos;re connected to</h4>
-                    <h2>{partner}</h2>
+                    <h2>{partner} ({partnerGender})</h2>
                 </div>
             </header>
 

--- a/src/components/sections/Greeting.tsx
+++ b/src/components/sections/Greeting.tsx
@@ -2,17 +2,18 @@ import RightIcon from "@/assets/icons/right";
 import { FormEvent, useRef } from "react";
 
 type GreetingProps = {
-    onSubmit: (name: string) => void
+    onSubmit: (name: string, gender: string) => void
 }
 
 export default function Greeting({ onSubmit }: GreetingProps) {
 
     const name = useRef<HTMLInputElement>(null);
+    const gender = useRef<HTMLSelectElement>(null);
 
     function onSubmitPrevent(e: FormEvent) {
         e.preventDefault();
-        if(name.current){
-            onSubmit(name.current.value);
+        if(name.current && gender.current && gender.current.value){
+            onSubmit(name.current.value, gender.current.value);
         }
     }
 
@@ -20,9 +21,18 @@ export default function Greeting({ onSubmit }: GreetingProps) {
     return (
         <section className="w-full h-full flex justify-center items-center">
             <form onSubmit={onSubmitPrevent} className="flex flex-col items-center gap-4 w-full">
-                <label className="flex flex-col items-center text-center w-full">
+                <label className="flex flex-col items-center text-center w-full mb-7">
                     <span className="text-[1.2em] font-[500]">Your Name</span>
                     <input ref={name} className="text-[3em] bg-inherit text-inherit font-[400] width-[10em] max-w-[90%] text-center outline-none border-b-2 border-foreground" type="text" placeholder="Pick a Name"/>
+                </label>
+                <label className="flex flex-col items-center text-center w-full">
+                    <span className="text-[1.2em] font-[500]">Your Gender</span>
+                    <select ref={gender} className="text-[3em] bg-inherit text-inherit font-[400] width-[10em] max-w-[90%] text-center outline-none border-b-2 border-foreground">
+                      <option value="" selected disabled>Select</option>
+                      <option value="m">Male</option>
+                      <option value="f">Female</option>
+                      <option value="o">I don&apos;t want to tell</option>
+                    </select>
                 </label>
                 <button className="flex font-[500]">Continue to Chat <RightIcon/> </button>
             </form>

--- a/src/hooks/useChatSocket.tsx
+++ b/src/hooks/useChatSocket.tsx
@@ -10,7 +10,9 @@ export const useChatSocket = () => {
 
     const [socket, setSocket] = useState<Socket<ServerToClientEvents, ClientToServerEvents> | null>(null);
     const [user, setUser] = useState<string | null>(null);
+    const [gender, setGender] = useState<string | null>(null);
     const [partner, setPartner] = useState<string | null>(null);
+    const [partnerGender, setPartnerGender] = useState<string | null>(null);
     const [isConnected, setIsConnected] = useState(false);
     const [isWaiting, setIsWaiting] = useState(false);
     const [messages, setMessages] = useState<Message[]>([]);
@@ -37,8 +39,9 @@ export const useChatSocket = () => {
             console.log("Waiting to connect");
         })
 
-        newSocket.on(ServerEvents.MATCHED, ({ partnerName }) => {
+        newSocket.on(ServerEvents.MATCHED, ({ partnerName, partnerGender }) => {
             setPartner(partnerName);
+            setPartnerGender(partnerGender);
             setIsWaiting(false);
             console.log("Matched with a Partner");
             setMessages([]);
@@ -54,9 +57,10 @@ export const useChatSocket = () => {
 
     }, [SOCKET_SERVER_URL])
 
-    const setUserName = useCallback((name: string) => {
-        socket?.emit(ClientEvents.INIT_USER, { name });
+    const setUserDetails = useCallback((name: string, gender: string) => {
+        socket?.emit(ClientEvents.INIT_USER, { name, gender });
         setUser(name);
+        setGender(gender);
     }, [socket]);
 
     const findPartner = useCallback(() => {
@@ -72,11 +76,13 @@ export const useChatSocket = () => {
 
     return {
         user,
+        gender,
         partner,
+        partnerGender,
         messages,
         isConnected,
         isWaiting,
-        setUserName,
+        setUserDetails,
         findPartner,
         sendMessage,
     }

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -18,7 +18,7 @@ export enum ServerEvents {
 }
 
 export interface ClientToServerEvents {
-    [ClientEvents.INIT_USER]: (data: { name: string }) => void;
+    [ClientEvents.INIT_USER]: (data: { name: string, gender: string }) => void;
     [ClientEvents.FIND_PARTNER]: () => void;
     [ClientEvents.SEND_MESSAGE]: (data: { message: string|null, image: string|null }) => void;
     [ClientEvents.SHARE_IMAGE]: (data: { image: string }) => void;
@@ -27,7 +27,7 @@ export interface ClientToServerEvents {
 
 export interface ServerToClientEvents {
     [ServerEvents.WAITING]: () => void;
-    [ServerEvents.MATCHED]: (data: { partnerName: string }) => void;
+    [ServerEvents.MATCHED]: (data: { partnerName: string, partnerGender: string }) => void;
     [ServerEvents.RECEIVE_MESSAGE]: (data: Message) => void;
     [ServerEvents.RECEIVE_IMAGE]: (data: { from: string; image: string }) => void;
     [ServerEvents.PARTNER_DISCONNECTED]: () => void;

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -3,6 +3,7 @@ import { Socket } from "socket.io-client";
 export interface User {
     id: string;
     name: string | null;
+    gender: string | null;
     socket: Socket;
     partner: string | null;
 }


### PR DESCRIPTION
This PR adds a select to ask the user for their gender and extends socket events to send and receive gender information, which is shown on the chat page besides the partner's name.

I will also open a supporting PR on the backend's repo

Closes #4