### PR TITLE
Retain Username across sessions

### DIFF
--- a/src/components/sections/Greeting.tsx
+++ b/src/components/sections/Greeting.tsx
@@ -1,5 +1,5 @@
 import RightIcon from "@/assets/icons/right";
-import { FormEvent, useRef } from "react";
+import { FormEvent, useEffect, useRef } from "react";
 
 type GreetingProps = {
     onSubmit: (name: string) => void
@@ -8,6 +8,15 @@ type GreetingProps = {
 export default function Greeting({ onSubmit }: GreetingProps) {
 
     const name = useRef<HTMLInputElement>(null);
+
+    useEffect(() => {
+      if (typeof window != 'undefined' && window.localStorage) {
+        const username = localStorage.getItem('username');
+        if (username) {
+          onSubmit(username);
+        }
+      }
+    })
 
     function onSubmitPrevent(e: FormEvent) {
         e.preventDefault();

--- a/src/hooks/useChatSocket.tsx
+++ b/src/hooks/useChatSocket.tsx
@@ -55,7 +55,6 @@ export const useChatSocket = () => {
     }, [SOCKET_SERVER_URL])
 
     const setUserName = useCallback((name: string) => {
-        console.log("Emitting", socket);
         socket?.emit(ClientEvents.INIT_USER, { name });
         setUser(name);
         if (typeof window != 'undefined' && window.localStorage) {

--- a/src/hooks/useChatSocket.tsx
+++ b/src/hooks/useChatSocket.tsx
@@ -55,8 +55,12 @@ export const useChatSocket = () => {
     }, [SOCKET_SERVER_URL])
 
     const setUserName = useCallback((name: string) => {
+        console.log("Emitting", socket);
         socket?.emit(ClientEvents.INIT_USER, { name });
         setUser(name);
+        if (typeof window != 'undefined' && window.localStorage) {
+          localStorage.setItem("username", name);
+        }
     }, [socket]);
 
     const findPartner = useCallback(() => {


### PR DESCRIPTION
The PR provides the foundation for persisting username (and potentially more info in future) across their sessions on purrr chat, allowing them to not being asked for username again and again, improving UX.

This can be improved upon by allowing them to change it without deleting site data (which removes the keys).

Saving to localStorage is done in `src/hooks/useChatSocket.tsx` `setUserName` method, and Greeting Component tries to restore username and calls onSubmit if success.

Closes #10