### PR TITLE
Implementation for WebRTC based Video Calling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ next-env.d.ts
 # text editors
 .zed
 .vscode
+
+certificates

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,7 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# text editors
+.zed
+.vscode

--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -4,11 +4,14 @@ import Greeting from "@/components/sections/Greeting";
 import NotConnected from "@/components/sections/NotConnected";
 import StartChatting from "@/components/sections/StartChatting";
 import WaitingForChat from "@/components/sections/WaitingForChat";
+import { VideoChat } from "@/components/resusable/VideoChat";
 import { useChatSocket } from "@/hooks/useChatSocket";
+import { useWebRTC } from "@/hooks/useWebRTC";
 
 export default function ChatPage() {
 
     const {
+        socket,
         user,
         partner,
         messages,
@@ -22,10 +25,17 @@ export default function ChatPage() {
         startTyping,
         stopTyping,
         partnerTyping,
-        requestVideoCall,
-        incomingCall,
         disconnect,
     } = useChatSocket();
+
+    const {
+        requestVideoCall,
+        incomingCall,
+        declineIncomingCall,
+        webRTCState,
+        startVideoCall,
+        // endVideoCall
+    } = useWebRTC(socket, partner);
 
     let content;
 
@@ -42,7 +52,8 @@ export default function ChatPage() {
                     content = <Chat partner={partner}
                         onMessage={sendMessage} messages={messages}
                         onVideoCall={requestVideoCall} incomingCall={incomingCall}
-                        onStop={disconnect}
+                        declineIncomingCall={declineIncomingCall}
+                        startVideoCall={startVideoCall} onStop={disconnect}
                         onReconnect={findPartner} readIndex={readIndex}
                         readMessage={readMessage} startTyping={startTyping}
                         stopTyping={stopTyping} partnerTyping={partnerTyping} />;
@@ -56,6 +67,7 @@ export default function ChatPage() {
     return (
         <main className="w-full h-full font-display">
             {content}
+            {webRTCState.connected && <VideoChat webRTCState={webRTCState} />}
         </main>
     );
 }

--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -8,50 +8,54 @@ import { useChatSocket } from "@/hooks/useChatSocket";
 
 export default function ChatPage() {
 
-  const {
-    user,
-    partner,
-    messages,
-    isConnected,
-    isWaiting,
-    readIndex,
-    setUserName,
-    findPartner,
-    sendMessage,
-    readMessage,
-    startTyping,
-    stopTyping,
-    partnerTyping,
-    disconnect,
-  } = useChatSocket();
+    const {
+        user,
+        partner,
+        messages,
+        isConnected,
+        isWaiting,
+        readIndex,
+        setUserName,
+        findPartner,
+        sendMessage,
+        readMessage,
+        startTyping,
+        stopTyping,
+        partnerTyping,
+        requestVideoCall,
+        incomingCall,
+        disconnect,
+    } = useChatSocket();
 
-  let content;
+    let content;
 
-  if (!isConnected) {
-    content = <NotConnected/>;
-  } else {  // if connected to server
-    if (!user) {
-      content = <Greeting onSubmit={setUserName} />;
-    } else { // if connected to server and username is set
-      if (!isWaiting) {
-        if (!partner) { // if user hasn't allowed to find matches
-          content = <StartChatting name={user} onConnect={findPartner} />;
-        } else { // if matches found
-          content = <Chat partner={partner}
-                          onMessage={sendMessage} messages={messages}
-                          onStop={disconnect} onReconnect={findPartner}
-                          readIndex={readIndex} readMessage={readMessage}
-                          startTyping={startTyping} stopTyping={stopTyping} partnerTyping={partnerTyping} />;
+    if (!isConnected) {
+        content = <NotConnected />;
+    } else {  // if connected to server
+        if (!user) {
+            content = <Greeting onSubmit={setUserName} />;
+        } else { // if connected to server and username is set
+            if (!isWaiting) {
+                if (!partner) { // if user hasn't allowed to find matches
+                    content = <StartChatting name={user} onConnect={findPartner} />;
+                } else { // if matches found
+                    content = <Chat partner={partner}
+                        onMessage={sendMessage} messages={messages}
+                        onVideoCall={requestVideoCall} incomingCall={incomingCall}
+                        onStop={disconnect}
+                        onReconnect={findPartner} readIndex={readIndex}
+                        readMessage={readMessage} startTyping={startTyping}
+                        stopTyping={stopTyping} partnerTyping={partnerTyping} />;
+                }
+            } else { // if user is waiting for a partner
+                content = <WaitingForChat />;
+            }
         }
-      } else { // if user is waiting for a partner
-        content = <WaitingForChat />;
-      }
     }
-  }
 
-  return (
-    <main className="w-full h-full font-display">
-      {content}
-    </main>
-  );
+    return (
+        <main className="w-full h-full font-display">
+            {content}
+        </main>
+    );
 }

--- a/src/components/resusable/VideoChat.tsx
+++ b/src/components/resusable/VideoChat.tsx
@@ -1,0 +1,37 @@
+import { WebRTCState } from "@/hooks/useWebRTC";
+
+type VideoChatProps = {
+    webRTCState: WebRTCState
+};
+
+export function VideoChat({ webRTCState }: VideoChatProps) {
+    return (
+        <div className="flex flex-row">
+            {
+                webRTCState.localStream && (
+                    <video
+                        autoPlay
+                        playsInline
+                        muted
+                        ref={video => {
+                            if (video) video.srcObject = webRTCState.localStream;
+                        }}
+                    />
+                )
+            }
+
+            {
+                webRTCState.remoteStream && (
+                    <video
+                        autoPlay
+                        playsInline
+                        muted
+                        ref={video => {
+                            if (video) video.srcObject = webRTCState.remoteStream;
+                        }}
+                    />
+                )
+            }
+        </div>
+    )
+}

--- a/src/components/sections/Chat.tsx
+++ b/src/components/sections/Chat.tsx
@@ -5,6 +5,7 @@ import { Message } from "@/types/messages";
 import { ChangeEvent, FormEvent, KeyboardEventHandler, useCallback, useEffect, useRef, useState } from "react";
 import ChatInput from "../resusable/ChatInput";
 import { ChatDisplay } from "../resusable/ChatDisplay";
+import AttachmentIcon from "@/assets/icons/attachment";
 
 type ChatProps = {
     partner: string,
@@ -12,6 +13,8 @@ type ChatProps = {
     readIndex: number | null,
     partnerTyping: boolean,
     onMessage: (message: string | null, image: string | null, reply: number | null) => void,
+    onVideoCall: () => void,
+    incomingCall: boolean,
     onStop: () => void,
     onReconnect: () => void,
     readMessage: (messageId: number) => void,
@@ -19,9 +22,9 @@ type ChatProps = {
     stopTyping: () => void,
 }
 
-export default function Chat({ 
-    partner, messages, readIndex, partnerTyping, onMessage, onStop,
-    onReconnect, readMessage, startTyping, stopTyping }: ChatProps
+export default function Chat({
+    partner, messages, readIndex, partnerTyping, onMessage, onVideoCall, incomingCall,
+    onStop, onReconnect, readMessage, startTyping, stopTyping }: ChatProps
 ) {
 
     const message = useRef<HTMLTextAreaElement>(null);
@@ -112,18 +115,18 @@ export default function Chat({
             scrollToBottom();
         });
         let ref = null;
-        if(chatInput.current) {
+        if (chatInput.current) {
             observer.observe(chatInput.current)
             ref = chatInput.current;
         }
 
         return () => {
-            if(ref) observer.unobserve(ref)
+            if (ref) observer.unobserve(ref)
         }
     }, [chatInput.current?.height, scrollToBottom])
 
     const onMessageChange: KeyboardEventHandler<HTMLTextAreaElement> = (e) => {
-        if(e.key === "Enter" && e.shiftKey === false) {
+        if (e.key === "Enter" && e.shiftKey === false) {
             e.preventDefault();
             submitMessage();
             return;
@@ -153,7 +156,7 @@ export default function Chat({
             setAttachment("");
         }
 
-        if(replyingTo !== null) {
+        if (replyingTo !== null) {
             reply = replyingTo;
             setReplyingTo(null);
         }
@@ -192,7 +195,7 @@ export default function Chat({
 
     function clearAttachment() {
         setAttachment("");
-        if(fileinput.current) fileinput.current.value = "";
+        if (fileinput.current) fileinput.current.value = "";
         message.current?.focus();
     }
 
@@ -204,7 +207,7 @@ export default function Chat({
     return (
         <section className={"w-full flex justify-center items-end relative font-text"}>
 
-            <ChatDisplay chatBottom={chatBottom} chatHeightOffset={chatHeightOffset} messages={messages} partner={partner} readIndex={readIndex} replyTo={replyTo}/>
+            <ChatDisplay chatBottom={chatBottom} chatHeightOffset={chatHeightOffset} messages={messages} partner={partner} readIndex={readIndex} replyTo={replyTo} />
 
             {unread > 0 && <button onClick={scrollToBottom} className="fixed bottom-[5em]">
                 <div className="bg-foreground font-[800] font-mono text-background text-[0.8em] w-5 h-5 flex justify-center items-center rounded-[50%] absolute right-0">{unread}</div>
@@ -216,6 +219,14 @@ export default function Chat({
                     <div className="">
                         <h4 className="text-[0.8em]">You&apos;re connected to</h4>
                         <h2>{partner} {partnerTyping && <small className="font-text">Typing...</small>}</h2>
+                    </div>
+                    {incomingCall && <div className="flex gap-2 ml-auto">
+                        Incoming Video Call
+                        <button className="p-2 rounded-full bg-green-500">Yes</button>
+                        <button className="p-2 rounded-full bg-red-500">No</button>
+                    </div>}
+                    <div className="flex gap-2 ml-auto mr-8">
+                        <button onClick={onVideoCall} disabled={incomingCall}><AttachmentIcon /></button>
                     </div>
                     <div className="flex gap-2">
                         <button onClick={onRefresh}><RefreshIcon /></button>

--- a/src/components/sections/Chat.tsx
+++ b/src/components/sections/Chat.tsx
@@ -14,7 +14,9 @@ type ChatProps = {
     partnerTyping: boolean,
     onMessage: (message: string | null, image: string | null, reply: number | null) => void,
     onVideoCall: () => void,
+    startVideoCall: () => void,
     incomingCall: boolean,
+    declineIncomingCall: () => void,
     onStop: () => void,
     onReconnect: () => void,
     readMessage: (messageId: number) => void,
@@ -23,7 +25,7 @@ type ChatProps = {
 }
 
 export default function Chat({
-    partner, messages, readIndex, partnerTyping, onMessage, onVideoCall, incomingCall,
+    partner, messages, readIndex, partnerTyping, onMessage, onVideoCall, incomingCall, startVideoCall, declineIncomingCall,
     onStop, onReconnect, readMessage, startTyping, stopTyping }: ChatProps
 ) {
 
@@ -222,8 +224,8 @@ export default function Chat({
                     </div>
                     {incomingCall && <div className="flex gap-2 ml-auto">
                         Incoming Video Call
-                        <button className="p-2 rounded-full bg-green-500">Yes</button>
-                        <button className="p-2 rounded-full bg-red-500">No</button>
+                        <button className="p-2 rounded-full bg-green-500" onClick={startVideoCall}>Yes</button>
+                        <button className="p-2 rounded-full bg-red-500" onClick={declineIncomingCall}>No</button>
                     </div>}
                     <div className="flex gap-2 ml-auto mr-8">
                         <button onClick={onVideoCall} disabled={incomingCall}><AttachmentIcon /></button>

--- a/src/hooks/useChatSocket.tsx
+++ b/src/hooks/useChatSocket.tsx
@@ -25,7 +25,6 @@ export const useChatSocket = () => {
     const [messages, setMessages] = useState<Message[]>([]);
     const [readIndex, setReadIndex] = useState<number | null>(null);
     const [partnerTyping, setPartnerTyping] = useState(false);
-    const [incomingCall, setIncomingCall] = useState(false);
 
     useEffect(() => {
         const newSocket = io(SOCKET_SERVER_URL) as Socket<ServerToClientEvents, ClientToServerEvents>;
@@ -89,10 +88,6 @@ export const useChatSocket = () => {
             setPartnerTyping(false);
         });
 
-        newSocket.on(ServerEvents.INCOMING_CALL, () => {
-            setIncomingCall(true);
-        });
-
         newSocket.on(ServerEvents.PARTNER_DISCONNECTED, async () => {
             setPartner(null);
             await storeKey(KeyTransaction.PARTNER_PK, null);
@@ -153,18 +148,12 @@ export const useChatSocket = () => {
         }
     }, [socket, partner]);
 
-    const requestVideoCall = useCallback(() => {
-        console.log(socket, partner)
-        if (socket && partner) {
-            socket.emit(ClientEvents.REQUEST_VIDEO_CALL);
-        }
-    }, [socket, partner]);
-
     const disconnect = useCallback(() => {
         socket?.emit(ClientEvents.DISCONNECT_PARTNER);
     }, [socket]);
 
     return {
+        socket,
         user,
         partner,
         messages,
@@ -178,8 +167,6 @@ export const useChatSocket = () => {
         readMessage,
         startTyping,
         stopTyping,
-        requestVideoCall,
-        incomingCall,
         disconnect,
     }
 }

--- a/src/hooks/useWebRTC.tsx
+++ b/src/hooks/useWebRTC.tsx
@@ -1,0 +1,174 @@
+import { ClientEvents, ClientToServerEvents, ServerEvents, ServerToClientEvents } from "@/types/events";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Socket } from "socket.io-client";
+
+export type WebRTCState = {
+    localStream: MediaStream | null;
+    remoteStream: MediaStream | null;
+    peerConnection: RTCPeerConnection | null;
+    connected: boolean;
+}
+
+export const useWebRTC = (socket: Socket<ServerToClientEvents, ClientToServerEvents> | null, partner: string | null) => {
+    const [webRTCState, setWebRTCState] = useState<WebRTCState>({
+        localStream: null,
+        remoteStream: null,
+        peerConnection: null,
+        connected: false
+    });
+
+    const peerConnectionRef = useRef<RTCPeerConnection | null>(null);
+
+    const [incomingCall, setIncomingCall] = useState(false);
+
+    const setupLocalStream = useCallback(async () => {
+        try {
+            const stream = await navigator.mediaDevices.getUserMedia({
+                video: true,
+                audio: true,
+            });
+
+            setWebRTCState(prev => ({ ...prev, localStream: stream }));
+
+            stream.getTracks().forEach(track => {
+                if (peerConnectionRef.current) {
+                    peerConnectionRef.current.addTrack(track, stream);
+                }
+            });
+        } catch (error) {
+            console.error('Error getting local stream:', error);
+        }
+    }, [peerConnectionRef]);
+
+    const setupPeerConnection = useCallback(() => {
+        const iceServers = {
+            iceServers: [
+                { urls: 'stun:stun.l.google.com:19302' },
+                { urls: 'stun:stun1.l.google.com:19302' },
+            ],
+        };
+
+        const peerConnection = new RTCPeerConnection(iceServers);
+        peerConnectionRef.current = peerConnection;
+
+        peerConnection.onicecandidate = (event) => {
+            if (event.candidate && socket) {
+                socket.emit(ClientEvents.SEND_CANDIDATE, event.candidate);
+            }
+        };
+
+        peerConnection.ontrack = (event) => {
+            setWebRTCState(prev => ({
+                ...prev,
+                remoteStream: event.streams[0]
+            }));
+        };
+
+        peerConnection.onconnectionstatechange = () => {
+            setWebRTCState(prev => ({
+                ...prev,
+                connected: peerConnection.connectionState === 'connected'
+            }));
+        };
+
+        setWebRTCState(state => ({ ...state, peerConnection }));
+
+        return peerConnection;
+    }, [socket]);
+
+    useEffect(() => {
+        if (!socket) return;
+
+        const peerConnection = setupPeerConnection();
+
+        socket.on(ServerEvents.INCOMING_CALL, () => {
+            setIncomingCall(true);
+        });
+
+        socket.on(ServerEvents.SET_OFFER, async (offer) => {
+            try {
+                await peerConnection.setRemoteDescription(new RTCSessionDescription(offer));
+                await setupLocalStream();
+                const answer = await peerConnection.createAnswer();
+                await peerConnection.setLocalDescription(answer);
+                socket.emit(ClientEvents.SEND_ANSWER, answer);
+            } catch (error) {
+                console.error('Error handling offer:', error);
+            }
+        })
+
+        socket.on(ServerEvents.SET_ANSWER, async (answer) => {
+            try {
+                await peerConnection.setRemoteDescription(new RTCSessionDescription(answer));
+            } catch (error) {
+                console.error('Error handling answer:', error);
+            }
+        })
+
+        socket.on(ServerEvents.SET_CANDIDATE, async (candidate) => {
+            try {
+                await peerConnection.addIceCandidate(new RTCIceCandidate(candidate));
+            } catch (error) {
+                console.error('Error handling ice candidate:', error);
+            }
+        });
+
+        return () => {
+            peerConnection.close();
+        }
+    }, [setupLocalStream, setupPeerConnection, socket]);
+
+    const requestVideoCall = useCallback(() => {
+        if (socket && partner) {
+            socket.emit(ClientEvents.REQUEST_VIDEO_CALL);
+        }
+    }, [socket, partner]);
+
+    const declineIncomingCall = useCallback(() => {
+        if (socket && partner) {
+            if (incomingCall) {
+                socket.emit(ClientEvents.DECLINE_INCOMING_CALL);
+                setIncomingCall(false);
+            }
+        }
+    }, [socket, partner, incomingCall]);
+
+    const startVideoCall = useCallback(async () => {
+        setIncomingCall(false);
+        try {
+            if (peerConnectionRef.current && socket) {
+                await setupLocalStream();
+
+                const offer = await peerConnectionRef.current.createOffer();
+                await peerConnectionRef.current.setLocalDescription(offer);
+                socket.emit(ClientEvents.SEND_OFFER, offer);
+            }
+        } catch (error) {
+            console.error('Error starting video call:', error);
+            throw error;
+        }
+    }, [setupLocalStream, socket]);
+
+    const endVideoCall = useCallback(() => {
+        webRTCState.localStream?.getTracks().forEach(track => track.stop());
+        peerConnectionRef.current?.close();
+
+        setWebRTCState({
+            localStream: null,
+            remoteStream: null,
+            peerConnection: null,
+            connected: false,
+        });
+
+        setupPeerConnection();
+    }, [setupPeerConnection, webRTCState]);
+
+    return {
+        requestVideoCall,
+        incomingCall,
+        declineIncomingCall,
+        webRTCState,
+        startVideoCall,
+        endVideoCall,
+    };
+}

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -7,7 +7,13 @@ export enum ClientEvents {
     READ_MESSAGE = 'read_message',
     TYPING_START = 'typing_start',
     TYPING_STOP = 'typing_stop',
+
     REQUEST_VIDEO_CALL = 'request_video_call',
+    DECLINE_INCOMING_CALL = 'decline_incoming_call',
+    SEND_OFFER = 'send_offer',
+    SEND_ANSWER = 'send_answer',
+    SEND_CANDIDATE = 'send_candidate',
+
     DISCONNECT_PARTNER = 'disconnect_partner'
 }
 
@@ -18,7 +24,12 @@ export enum ServerEvents {
     MARK_AS_READ = 'mark_as_read',
     SHOW_TYPING = 'show_typing',
     HIDE_TYPING = 'hide_typing',
+
     INCOMING_CALL = 'incoming_call',
+    SET_OFFER = 'set_offer',
+    SET_ANSWER = 'set_answer',
+    SET_CANDIDATE = 'set_candidate',
+
     PARTNER_DISCONNECTED = 'partner_disconnected',
     ERROR = 'error'
 }
@@ -26,11 +37,17 @@ export enum ServerEvents {
 export interface ClientToServerEvents {
     [ClientEvents.INIT_USER]: (data: { name: string, publicKey: string }) => void;
     [ClientEvents.FIND_PARTNER]: () => void;
-    [ClientEvents.SEND_MESSAGE]: (data: { message: string|null, image: string|null, reply: number | null }) => void;
+    [ClientEvents.SEND_MESSAGE]: (data: { message: string | null, image: string | null, reply: number | null }) => void;
     [ClientEvents.READ_MESSAGE]: (data: { messageId: number }) => void;
     [ClientEvents.TYPING_START]: () => void;
     [ClientEvents.TYPING_STOP]: () => void;
+
     [ClientEvents.REQUEST_VIDEO_CALL]: () => void;
+    [ClientEvents.DECLINE_INCOMING_CALL]: () => void;
+    [ClientEvents.SEND_OFFER]: (data: RTCSessionDescriptionInit) => void;
+    [ClientEvents.SEND_ANSWER]: (data: RTCSessionDescriptionInit) => void;
+    [ClientEvents.SEND_CANDIDATE]: (data: RTCIceCandidateInit) => void;
+
     [ClientEvents.DISCONNECT_PARTNER]: () => void;
 }
 
@@ -38,10 +55,15 @@ export interface ServerToClientEvents {
     [ServerEvents.WAITING]: () => void;
     [ServerEvents.MATCHED]: (data: { partnerName: string, partnerPk: string }) => void;
     [ServerEvents.RECEIVE_MESSAGE]: (data: Message) => void;
-    [ServerEvents.MARK_AS_READ]: (data: {messageId: number}) => void;
+    [ServerEvents.MARK_AS_READ]: (data: { messageId: number }) => void;
     [ServerEvents.SHOW_TYPING]: () => void;
     [ServerEvents.HIDE_TYPING]: () => void;
+
     [ServerEvents.INCOMING_CALL]: () => void;
+    [ServerEvents.SET_OFFER]: (data: RTCSessionDescriptionInit) => void;
+    [ServerEvents.SET_ANSWER]: (data: RTCSessionDescriptionInit) => void;
+    [ServerEvents.SET_CANDIDATE]: (data: RTCIceCandidateInit) => void;
+
     [ServerEvents.PARTNER_DISCONNECTED]: () => void;
     [ServerEvents.ERROR]: (data: { message: string }) => void;
 }

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -7,6 +7,7 @@ export enum ClientEvents {
     READ_MESSAGE = 'read_message',
     TYPING_START = 'typing_start',
     TYPING_STOP = 'typing_stop',
+    REQUEST_VIDEO_CALL = 'request_video_call',
     DISCONNECT_PARTNER = 'disconnect_partner'
 }
 
@@ -17,6 +18,7 @@ export enum ServerEvents {
     MARK_AS_READ = 'mark_as_read',
     SHOW_TYPING = 'show_typing',
     HIDE_TYPING = 'hide_typing',
+    INCOMING_CALL = 'incoming_call',
     PARTNER_DISCONNECTED = 'partner_disconnected',
     ERROR = 'error'
 }
@@ -28,6 +30,7 @@ export interface ClientToServerEvents {
     [ClientEvents.READ_MESSAGE]: (data: { messageId: number }) => void;
     [ClientEvents.TYPING_START]: () => void;
     [ClientEvents.TYPING_STOP]: () => void;
+    [ClientEvents.REQUEST_VIDEO_CALL]: () => void;
     [ClientEvents.DISCONNECT_PARTNER]: () => void;
 }
 
@@ -38,6 +41,7 @@ export interface ServerToClientEvents {
     [ServerEvents.MARK_AS_READ]: (data: {messageId: number}) => void;
     [ServerEvents.SHOW_TYPING]: () => void;
     [ServerEvents.HIDE_TYPING]: () => void;
+    [ServerEvents.INCOMING_CALL]: () => void;
     [ServerEvents.PARTNER_DISCONNECTED]: () => void;
     [ServerEvents.ERROR]: (data: { message: string }) => void;
 }


### PR DESCRIPTION
This PR implements simple WebRTC based Video Calls. When in a chat, click the attachment button at the top (limited UI design right now), this sends a call request on the other side, showing an incoming call banner with accept and decline buttons. Declining just dismisses the banner (no events sent over, probably a good idea to add one)

Accepting starts sending a series of events to exchange offers, answers, and setups local cameras on both sides. All that event handling is added to the `src/hooks/useWebRTC.tsx` hook. Reconnections and Hangups are still left to be implemented.

Newly added client events are:

```ts
REQUEST_VIDEO_CALL = 'request_video_call',
DECLINE_INCOMING_CALL = 'decline_incoming_call',
SEND_OFFER = 'send_offer',
SEND_ANSWER = 'send_answer',
SEND_CANDIDATE = 'send_candidate',
```
The VideoChat component is also pretty limited UI.
